### PR TITLE
Allow skipping commits tagged by CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ following property:
   all branches are tracked.
 * `exclude`: *Optional* A Regex for branches to be excluded. If not specified,
   no branches are excluded.
+* `enable_ci_skip`: *Optional.* Enable skipping commits with "[ci skip]" or "[skip ci]" tag. This may have an impact on check performance.
 
 The `branch` configuration from the original resource is ignored for `check`.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ following property:
   all branches are tracked.
 * `exclude`: *Optional* A Regex for branches to be excluded. If not specified,
   no branches are excluded.
-* `enable_ci_skip`: *Optional.* Enable skipping commits with "[ci skip]" or "[skip ci]" tag. This may have an impact on check performance.
+* `enable_ci_skip`: *Optional.* Enable skipping commits with subject containing a "[ci skip]" or "[skip ci]" tag. This may have an impact on check performance.
 
 The `branch` configuration from the original resource is ignored for `check`.
 

--- a/assets/check
+++ b/assets/check
@@ -29,18 +29,15 @@ configure_git_global "${git_config_payload}"
 # Clone repo to make commit log available
 if [ "$skip_ci_enabled" == "true" ]; then
     REPO=$TMPDIR/git-branch-heads-resource-repo-cache
-    if [ -d $REPO ]; then
-        cd $REPO
-        git fetch
-    else
+    if [ ! -d $REPO ]; then
         git clone --bare "$uri" $REPO
-        cd $REPO
     fi
 fi
 
 e_point=!
 current_heads=$(git ls-remote -h "$uri" $branch_filter | sed 's/refs\/heads\///' | awk '{print $2, $1}' | awk "\$1 $e_point~ \"^($exclude_branches)$\"" | sort -V)
 
+# this map will always list the most recent refs, even if they are skipped
 current_heads_map=$(
   jq -n '
     $heads | rtrimstr("\n") | split("\n") |
@@ -55,19 +52,35 @@ echo "$current_heads" |
       continue
     fi
 
-    if [ "$skip_ci_enabled" == "true" ]; then
-        # update branch refs
-        git fetch "$uri" "$branch"
-        ref_msg=$(git log --format=%s -1 $ref)
-        if [[ "$ref_msg" =~ "[ci skip]" ]] || [[ "$ref_msg" =~ "[skip ci]" ]]; then
-            continue
+    prev_ref=$(jq -r '.version | .[$branch]' --arg branch "$branch" < $payload)
+
+    if [ "$ref" == "$prev_ref" ]; then
+        continue;
+    else
+        if [ "$skip_ci_enabled" == "true" ]; then
+            # update branch refs
+            git -C $REPO fetch "$uri" "$branch"
+
+            # check all refs since $prev_ref to find one that should not be skipped
+            last_unskipped_ref=$(
+                git -C $REPO log --format="%H %s" ${prev_ref}..${ref} |
+                    while read i_ref msg; do
+                        if [[ "$msg" =~ "[ci skip]" ]] || [[ "$msg" =~ "[skip ci]" ]]; then
+                            continue
+                        else
+                            echo "$i_ref"
+                            break
+                        fi
+                    done)
+
+            if [ ! -z "$last_unskipped_ref" ]; then
+                echo "$branch"
+            fi
+        else
+            echo "$branch"
         fi
     fi
 
-    prev_ref=$(jq -r '.version | .[$branch]' --arg branch "$branch" < $payload)
-    if [ "$ref" != "$prev_ref" ]; then
-      echo "$branch"
-    fi
   done |
   jq -R . |
   jq -s 'map({changed: .} + $branches)' \

--- a/assets/check
+++ b/assets/check
@@ -44,7 +44,7 @@ echo "$current_heads" |
     fi
 
     if [ "$skip_ci_enabled" == "true" ]; then
-        ref_msg=`git log --format=%B -1 $ref`
+        ref_msg=$(git log --format=%s -1 $ref)
         if [[ "$ref_msg" =~ "[ci skip]" ]] || [[ "$ref_msg" =~ "[skip ci]" ]]; then
             continue
         fi

--- a/assets/check
+++ b/assets/check
@@ -20,6 +20,7 @@ uri=$(jq -r '.source.uri // ""' < $payload)
 exclude_branches=$(jq -r '.source.exclude // ""' < $payload)
 branch_filter=$(jq -r '.source.branches // [] | join(" ")' < $payload)
 git_config_payload=$(jq -r '.source.git_config // []' < $payload)
+skip_ci_enabled=$(jq -r '.source.enable_ci_skip // false' < $payload)
 
 previous_branches="$(jq -r '.version.branches // ""' < $payload)"
 
@@ -40,6 +41,13 @@ echo "$current_heads" |
   while read branch ref; do
     if [ -z "$branch" ]; then
       continue
+    fi
+
+    if [ "$skip_ci_enabled" == "true" ]; then
+        ref_msg=`git log --format=%B -1 $ref`
+        if [[ "$ref_msg" =~ "[ci skip]" ]] || [[ "$ref_msg" =~ "[skip ci]" ]]; then
+            continue
+        fi
     fi
 
     prev_ref=$(jq -r '.version | .[$branch]' --arg branch "$branch" < $payload)

--- a/assets/check
+++ b/assets/check
@@ -56,6 +56,8 @@ echo "$current_heads" |
     fi
 
     if [ "$skip_ci_enabled" == "true" ]; then
+        # update branch refs
+        git fetch "$uri" "$branch"
         ref_msg=$(git log --format=%s -1 $ref)
         if [[ "$ref_msg" =~ "[ci skip]" ]] || [[ "$ref_msg" =~ "[skip ci]" ]]; then
             continue

--- a/assets/check
+++ b/assets/check
@@ -26,6 +26,18 @@ previous_branches="$(jq -r '.version.branches // ""' < $payload)"
 
 configure_git_global "${git_config_payload}"
 
+# Clone repo to make commit log available
+if [ "$skip_ci_enabled" == "true" ]; then
+    REPO=$TMPDIR/git-branch-heads-resource-repo-cache
+    if [ -d $REPO ]; then
+        cd $REPO
+        git fetch
+    else
+        git clone --bare "$uri" $REPO
+        cd $REPO
+    fi
+fi
+
 e_point=!
 current_heads=$(git ls-remote -h "$uri" $branch_filter | sed 's/refs\/heads\///' | awk '{print $2, $1}' | awk "\$1 $e_point~ \"^($exclude_branches)$\"" | sort -V)
 


### PR DESCRIPTION
This commit introduces an option to enable ignoring commits with a '[ci skip]' tag. It is turned off by default.