### PR TITLE
Fix check operation for new branches

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -62,8 +62,13 @@ echo "$current_heads" |
             git -C $REPO fetch "$uri" "$branch"
 
             # check all refs since $prev_ref to find one that should not be skipped
+            if [ "$prev_ref" == "null" ]; then
+                refs_to_check="-1 $ref"
+            else
+                refs_to_check="${prev_ref}..${ref}"
+            fi
             last_unskipped_ref=$(
-                git -C $REPO log --format="%H %s" ${prev_ref}..${ref} |
+                git -C $REPO log --format="%H %s" $refs_to_check |
                     while read i_ref msg; do
                         if [[ "$msg" =~ "[ci skip]" ]] || [[ "$msg" =~ "[skip ci]" ]]; then
                             continue

--- a/assets/check
+++ b/assets/check
@@ -62,6 +62,7 @@ echo "$current_heads" |
             git -C $REPO fetch "$uri" "$branch"
 
             # check all refs since $prev_ref to find one that should not be skipped
+            # if a branch is new ($prev_ref == null), check only the last commit
             if [ "$prev_ref" == "null" ]; then
                 refs_to_check="-1 $ref"
             else


### PR DESCRIPTION
For new branches the "prev_ref" variable is set to "null", so the check failed because of invalid ref range. I changed the script to check only the last commit in such case.